### PR TITLE
Remove C style structs

### DIFF
--- a/examples/messaging/pytest_test_messaging.py
+++ b/examples/messaging/pytest_test_messaging.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+
 def test_app(dut):
     dut.expect("Hello, Responder!")
     dut.expect("Oh hi there, Caller!")

--- a/examples/minimal/pytest_test_minimal.py
+++ b/examples/minimal/pytest_test_minimal.py
@@ -2,5 +2,6 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+
 def test_app(dut):
     dut.expect("Hello, World!")

--- a/include/Actor.hpp
+++ b/include/Actor.hpp
@@ -16,7 +16,7 @@ typedef enum : uint8_t {
   DIRECTIVE_EXIT,
 } Directive;
 
-typedef struct Message {
+struct Message {
   Message() : directive(DIRECTIVE_HANDLE), signal(0), data(nullptr){};
   Message(int signal)
       : directive(DIRECTIVE_HANDLE), signal(signal), data(nullptr){};
@@ -25,7 +25,7 @@ typedef struct Message {
   Directive directive;
   int signal;
   void *data;
-} Message;
+};
 
 class Actor {
 private:

--- a/test_app/pytest_test_app.py
+++ b/test_app/pytest_test_app.py
@@ -2,5 +2,6 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+
 def test_app(dut):
     dut.expect_unity_test_output(timeout=240)


### PR DESCRIPTION
The C style structs with `typedef struct` seem to be breaking the documentation build in the `kywy` repository.